### PR TITLE
feat: Add hide/unhide functionality for audio and video files

### DIFF
--- a/lib/data/services/file_service/file_service.dart
+++ b/lib/data/services/file_service/file_service.dart
@@ -34,4 +34,52 @@ class FileService {
   String getFileNameWithExtension(String path) {
   return  pth.basenameWithoutExtension(path);
   }
+
+  //-- Hide a file by adding a dot prefix
+  Future<void> hideFile(String filePath) async {
+    try {
+      final file = File(filePath);
+      if (await file.exists()) {
+        final directory = file.parent.path;
+        final fileName = pth.basename(filePath);
+        if (!fileName.startsWith('.')) {
+          final newPath = '$directory/.$fileName';
+          await file.rename(newPath);
+        }
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  //-- Unhide a file by removing the dot prefix
+  Future<void> unhideFile(String filePath) async {
+    try {
+      final file = File(filePath);
+      if (await file.exists()) {
+        final directory = file.parent.path;
+        final fileName = pth.basename(filePath);
+        if (fileName.startsWith('.')) {
+          final newPath = '$directory/${fileName.substring(1)}';
+          await file.rename(newPath);
+        }
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  //-- Check if a file is hidden
+  bool isFileHidden(String filePath) {
+    return pth.basename(filePath).startsWith('.');
+  }
+
+  //-- Toggle hide/unhide a file
+  Future<void> toggleHideFile(String filePath) async {
+    if (isFileHidden(filePath)) {
+      await unhideFile(filePath);
+    } else {
+      await hideFile(filePath);
+    }
+  }
 }

--- a/lib/presentation/common/widgets/ElegantVideoTileWidget.dart
+++ b/lib/presentation/common/widgets/ElegantVideoTileWidget.dart
@@ -155,6 +155,16 @@ class ElegantVideoTileWidget extends StatelessWidget {
             onPressed: () => _renameVideo(context),
           ),
 
+          // Hide/Unhide Option
+          _buildActionSheetAction(
+            context,
+            text: FileService().isFileHidden(video.path) ? 'Unhide' : 'Hide',
+            icon: FileService().isFileHidden(video.path) 
+                ? CupertinoIcons.eye 
+                : CupertinoIcons.eye_slash,
+            onPressed: () => _toggleHideVideo(context),
+          ),
+
           // Delete Option
           _buildActionSheetAction(
             context,
@@ -277,6 +287,12 @@ class ElegantVideoTileWidget extends StatelessWidget {
         );
       },
     );
+  }
+
+  void _toggleHideVideo(BuildContext context) {
+    FileService().toggleHideFile(video.path).whenComplete(() {
+      context.read<VideosBloc>().add(VideosLoadEvent());
+    });
   }
 
   void _deleteVideo(BuildContext context) {

--- a/lib/presentation/pages/audio/sub/songs/widgets/song_tile_more_button_widget.dart
+++ b/lib/presentation/pages/audio/sub/songs/widgets/song_tile_more_button_widget.dart
@@ -35,6 +35,7 @@ class SongTileMoreButtonWidget extends StatelessWidget {
             items: [
               _musicAddToFavorite(path),
               _renameMusic(context, path, audio.title),
+              _toggleHideMusic(context, path),
               _deleteMusic(
                 context,
                 path,
@@ -129,6 +130,23 @@ PopupMenuItem<dynamic> _renameMusic(
         "Rename",
       ),
       trailing: Icon(Icons.text_snippet),
+    ),
+  );
+}
+
+///--------------- T O G G L E  H I D E
+PopupMenuItem<dynamic> _toggleHideMusic(BuildContext context, String path) {
+  final isHidden = FileService().isFileHidden(path);
+  return PopupMenuItem(
+    onTap: () async {
+      await FileService().toggleHideFile(path);
+      context.read<AudiosBloc>().add(AudiosLoadAllEvent());
+    },
+    child: ListTile(
+      title: Text(
+        isHidden ? "Unhide" : "Hide",
+      ),
+      trailing: Icon(isHidden ? Icons.visibility : Icons.visibility_off),
     ),
   );
 }


### PR DESCRIPTION
Add ability to hide/unhide audio and video files by adding/removing a dot prefix to filenames.

- Add hide/unhide methods to FileService
- Add hide/unhide option in video and audio menus
- Update lists after hide/unhide

Fixes #10